### PR TITLE
Add Better Error Handling for TMDB API

### DIFF
--- a/media/main.go
+++ b/media/main.go
@@ -26,6 +26,10 @@ func ParseFilename(filename string, tvShow bool) (Media, error) {
 		if err != nil {
 			return Media{}, err
 		}
-		return Media{Title: title, Year: year}, nil
+		genre, err := getPrimaryGenre(title, year)
+		if err != nil {
+			return Media{Title: title, Year: year}, err
+		}
+		return Media{Title: title, Year: year, Genre: genre}, nil
 	}
 }

--- a/media/tmdb.go
+++ b/media/tmdb.go
@@ -110,6 +110,10 @@ func getPrimaryGenre(title string, year string) (string, error) {
 		return "", errors.New("no movie found")
 	}
 
+	if len(movies.Results[0].GenreIds) == 0 {
+		return "", errors.New("no genre found")
+	}
+
 	genreId := movies.Results[0].GenreIds[0]
 
 	return genreMap[genreId], nil


### PR DESCRIPTION
Closes #20 by adding error handling when an identified movie does not have associated genres.